### PR TITLE
expand hugginface reponame matching logistics to support '-'

### DIFF
--- a/aiflows/flow_verse/loading.py
+++ b/aiflows/flow_verse/loading.py
@@ -299,7 +299,7 @@ def validate_and_augment_dependency(dependency: Dict[str, str], caller_module_na
     if "url" not in dependency:  # TODO(yeeef): url is not descriptive
         raise ValueError("dependency must have a `url` field")
 
-    match = re.search(r"^(\w+)/(\w+)$", dependency["url"])
+    match = re.search(r"^([\w-]+)/([\w-]+)$", dependency["url"])
     if not match:
         raise ValueError("dependency url must be in the format of `username/repo_name`(huggingface repo)")
     username, repo_name = match.group(1), match.group(2)


### PR DESCRIPTION
The previous matching logic does not match the '-' symbol.

For example, if my huggingface account id is "Tachi-67" then the match will fail, which is not expected.

This pr resolves this issue.