### PR TITLE
Feature/add keyunpack to datatransformations

### DIFF
--- a/aiflows/data_transformations/__init__.py
+++ b/aiflows/data_transformations/__init__.py
@@ -9,3 +9,4 @@ from .regex_extractor_first import RegexFirstOccurrenceExtractor
 from .json import Json2Obj, Obj2Json
 from .unnesting_dict import UnNesting
 from .print_previous_messages import PrintPreviousMessages
+from .key_unpack import KeyUnpack

--- a/aiflows/data_transformations/key_unpack.py
+++ b/aiflows/data_transformations/key_unpack.py
@@ -1,0 +1,53 @@
+from typing import Dict, Any, List
+
+from aiflows.data_transformations.abstract import DataTransformation
+from aiflows.utils.logging import get_logger
+from aiflows.utils.general_helpers import nested_keys_search
+
+log = get_logger(__name__)
+
+
+class KeyUnpack(DataTransformation):
+    """This class unpacks one layer of the nested data dictionary.
+    :param keys_to_unpack: A list of keys to unpack
+    :type keys_to_unpack: List[str]
+    :return The unpacked data dictionary
+
+    example:
+    keys_to_unpack: ["observation"]
+    data_dict = {
+    "observation":
+        "code": "some code",
+        "file_loc": "some path",
+        "human_feedback": "some feedback"
+    }
+    output = {
+    "code": "some code",
+    "file_loc": "some path",
+    "human_feedback":"some feedback"
+    }
+    """
+
+    def __init__(self,
+                 keys_to_unpack: List[str],
+                 nested_keys: bool = True
+                 ):
+        super().__init__()
+        self.keys_to_unpack = keys_to_unpack
+        self.nested_keys = nested_keys
+
+    def __call__(self, data_dict: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        ret = data_dict.copy()
+        if self.nested_keys:
+            for key_to_unpack in self.keys_to_unpack:
+                nested_keys = key_to_unpack.split(".")
+                value, found = nested_keys_search(ret, key_to_unpack)
+                if found and len(nested_keys) > 1:
+                    parent_key = nested_keys[0]
+                    ret[parent_key] = value
+                elif found and len(nested_keys) == 1:
+                    ret = value
+        else:
+            for key_to_unpack in self.keys_to_unpack:
+                ret = ret.get(key_to_unpack, ret)
+        return ret

--- a/aiflows/data_transformations/key_unpack.py
+++ b/aiflows/data_transformations/key_unpack.py
@@ -10,21 +10,44 @@ log = get_logger(__name__)
 class KeyUnpack(DataTransformation):
     """This class unpacks one layer of the nested data dictionary.
     :param keys_to_unpack: A list of keys to unpack
+    :param nested_keys: Whether the keys are nested or not, defaults to True
     :type keys_to_unpack: List[str]
+    :type nested_keys: bool, optional
     :return The unpacked data dictionary
 
     example:
     keys_to_unpack: ["observation"]
     data_dict = {
-    "observation":
-        "code": "some code",
-        "file_loc": "some path",
-        "human_feedback": "some feedback"
+        "observation":
+            {
+                "code": "some code",
+                "file_loc": "some path",
+                "human_feedback": "some feedback"
+            }
     }
     output = {
     "code": "some code",
     "file_loc": "some path",
     "human_feedback":"some feedback"
+    }
+
+    example2:
+    keys_to_unpack: ["observation.A"]
+    data_dict = {
+        "observation": {
+            "A": {
+                "code": "some code",
+                "file_loc": "some path",
+                "human_feedback": "some feedback"
+            }
+        }
+    }
+    output = {
+    "observation": {
+        "code": "some code",
+        "file_loc": "some path",
+        "human_feedback":"some feedback"
+        }
     }
     """
 
@@ -37,6 +60,14 @@ class KeyUnpack(DataTransformation):
         self.nested_keys = nested_keys
 
     def __call__(self, data_dict: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        """
+        Applies the transformation to the given data dictionary. It unpacks one layer of the nested data dictionary.
+        :param data_dict: The data dictionary to apply the transformation to
+        :type data_dict: Dict[str, Any]
+        :param \**kwargs: Arbitrary keyword arguments
+        :return: The transformed data dictionary
+        :rtype: Dict[str, Any]
+        """
         ret = data_dict.copy()
         if self.nested_keys:
             for key_to_unpack in self.keys_to_unpack:

--- a/aiflows/data_transformations/key_unpack.py
+++ b/aiflows/data_transformations/key_unpack.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, List
 
 from aiflows.data_transformations.abstract import DataTransformation
 from aiflows.utils.logging import get_logger
-from aiflows.utils.general_helpers import nested_keys_search
+from aiflows.utils.general_helpers import nested_keys_search, nested_keys_pop
 
 log = get_logger(__name__)
 
@@ -75,10 +75,12 @@ class KeyUnpack(DataTransformation):
                 value, found = nested_keys_search(ret, key_to_unpack)
                 if found and len(nested_keys) > 1:
                     parent_key = nested_keys[0]
-                    ret[parent_key] = value
+                    ret[parent_key].update(value)
+                    nested_keys_pop(ret, key_to_unpack)
                 elif found and len(nested_keys) == 1:
-                    ret = value
+                    ret.update(value)
+                    nested_keys_pop(ret, key_to_unpack)
         else:
             for key_to_unpack in self.keys_to_unpack:
-                ret = ret.get(key_to_unpack, ret)
+                ret.update(ret.pop(key_to_unpack))
         return ret

--- a/aiflows/interfaces/key_interface.py
+++ b/aiflows/interfaces/key_interface.py
@@ -4,7 +4,7 @@ from typing import Dict, Any, List
 
 import hydra
 
-from aiflows.data_transformations import KeySelect, KeyRename, KeyCopy, KeySet, KeyDelete
+from aiflows.data_transformations import KeySelect, KeyRename, KeyCopy, KeySet, KeyDelete, KeyUnpack
 
 
 class KeyInterface(ABC):
@@ -48,6 +48,7 @@ class KeyInterface(ABC):
         additional_transformations: List = [],
         keys_to_select: List[str] = [],
         keys_to_delete: List[str] = [],
+        keys_to_unpack: List[str] = [],
     ):
         self.transformations = []
 
@@ -65,6 +66,8 @@ class KeyInterface(ABC):
             self.transformations.append(KeySelect(keys_to_select))
         if keys_to_delete:
             self.transformations.append(KeyDelete(keys_to_delete))
+        if keys_to_unpack:
+            self.transformations.append(KeyUnpack(keys_to_unpack))
 
     def __call__(self, goal, src_flow, dst_flow, data_dict: Dict[str, Any], **kwargs) -> Dict[str, Any]:
         r"""Applies the all transformations to the given data dictionary.


### PR DESCRIPTION
Add a new data transformation: `KeyUnpack`, this transformation is able to unpack nested dictionaries given keys (can be passed in the nested fashion e.g. `key_name_A.key_name_B`).

For example:
`    keys_to_unpack: ["observation"]`
```
    data_dict = {
        "observation":
            {
                "code": "some code",
                "file_loc": "some path",
                "human_feedback": "some feedback"
            }
    }
```
```
    output = {
    "code": "some code",
    "file_loc": "some path",
    "human_feedback":"some feedback"
    }
```

This transformation is useful with nested flows (e.g. `branchingflow`), when we want to directly have the output from the subflows (one of the branches) and get rid of the surface output layer of the branching flow.

This transformation is more convenient than `keys_rename` because there is no need to specify the names of the subflows outputs (and also, their respective renames), using this transformation and directly providing the surface layer key will suffice.